### PR TITLE
Colored instructions

### DIFF
--- a/Assets/Scenes/SilverAtomNodeBuilder.unity
+++ b/Assets/Scenes/SilverAtomNodeBuilder.unity
@@ -389,7 +389,7 @@ GameObject:
   - component: {fileID: 345286469}
   - component: {fileID: 345286468}
   m_Layer: 6
-  m_Name: Text (TMP)
+  m_Name: CompleteText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -410,9 +410,9 @@ RectTransform:
   m_Father: {fileID: 735426792}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 270}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &345286468
@@ -435,7 +435,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\n\n\n\n\n     Incomplete Setup"
+  m_text: 'Text
+
+'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -468,7 +470,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 1
+  m_fontStyle: 17
   m_HorizontalAlignment: 1
   m_VerticalAlignment: 256
   m_textAlignment: 65535
@@ -1255,6 +1257,7 @@ MonoBehaviour:
   xml: {fileID: 1103304288}
   nbSource: {fileID: 396536982}
   instructionCamera: {fileID: 1930399475}
+  completeText: {fileID: 345286468}
 --- !u!4 &1799884473
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/Experiment.cs
+++ b/Assets/Scripts/Core/Experiment.cs
@@ -18,9 +18,6 @@ namespace SternGerlach.Assets.Scripts.Core
         public string moveForwardToMCQMessage;
         // CAMERA SETTINGS
         public float sizeModifier = 0f, yPosModifier = 0f, xPosModifier = 0f;
-        void Start() {
-            guidedComponent.SetCameraSettings(sizeModifier,xPosModifier,yPosModifier);
-        }
         public string ToString() {
             string debugString = "Nodes: \n";
             debugString += NodeToString(source);

--- a/Assets/Scripts/Core/ExperimentBuilder.cs
+++ b/Assets/Scripts/Core/ExperimentBuilder.cs
@@ -10,7 +10,7 @@ namespace SternGerlach.Assets.Scripts.Core
         private string id = "DEFAULT_EXPERIMENT_NAME";
 
         // INSTRUCTION SETTINGS
-        private float sizemodifier = 0f, xposmodifier = 0f, yposmodifier = 0f;
+        private float sizeModifier = 0f, xPosModifier = 0f, yPosModifier = 0f;
 
         // MCQ (A: <Message>)
         private MCQuestion mcq = new MCQuestion();
@@ -34,9 +34,10 @@ namespace SternGerlach.Assets.Scripts.Core
             exp.minParticles = minParticles;
             exp.moveForwardToMCQMessage = moveForwardToMCQMessage;
             exp.guidedComponent = guidedComponent;
-            exp.sizeModifier = sizemodifier;
-            exp.xPosModifier = xposmodifier;
-            exp.yPosModifier= yposmodifier;
+            exp.sizeModifier = sizeModifier;
+            exp.xPosModifier = xPosModifier;
+            exp.yPosModifier = yPosModifier;
+            guidedComponent.SetCameraSettings(sizeModifier, xPosModifier, yPosModifier);
             return exp;
         }
         public void SetGuidedComponent(GuidedComponent guidedComponent) {
@@ -73,13 +74,13 @@ namespace SternGerlach.Assets.Scripts.Core
             switch (type)
             {
                 case "sizemodifier":
-                    this.sizemodifier = modification;
+                    this.sizeModifier = modification;
                     break;
                 case "xposmodifier":
-                    this.xposmodifier = modification;
+                    this.xPosModifier = modification;
                     break;
                 case "yposmodifier":
-                    this.yposmodifier = modification;
+                    this.yPosModifier = modification;
                     break;
             }
         }

--- a/Assets/Scripts/Core/GuidedComponent.cs
+++ b/Assets/Scripts/Core/GuidedComponent.cs
@@ -1,6 +1,7 @@
 using SternGerlach.Assets.Scripts.Core;
 using System.Collections;
 using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
@@ -14,6 +15,7 @@ namespace SternGerlach
         [SerializeField] public XMLDeserializer xml;
         [SerializeField] Source nbSource;
         [SerializeField] Camera instructionCamera;
+        [SerializeField] TextMeshProUGUI completeText;
         private Source instSource;
         // initial camera settings
         private float initX = Globals.INST_CAM_INIT_X, initY = Globals.INST_CAM_INIT_Y, initSize = Globals.INST_CAM_INIT_SIZE;
@@ -26,16 +28,23 @@ namespace SternGerlach
         }
         void Update()
         {
-            this.exp = xml.currExp;
-            instSource = exp.source;
-            nbSource.UpdateInstructionColoring(instSource);
+            TryEqual();
         }
         public bool TryEqual()
         {
             this.exp = xml.currExp;
             instSource = exp.source;
+            bool eq = nbSource.Equals(instSource);
             nbSource.UpdateInstructionColoring(instSource);
-            return nbSource.Equals(instSource);
+            if (eq)
+            {
+                completeText.text = "Complete setup!";
+            }
+            else
+            {
+                completeText.text = "Incomplete setup.";
+            }
+            return eq;
         }
         public void DebugTrees() 
         {

--- a/Assets/Scripts/Core/GuidedComponent.cs
+++ b/Assets/Scripts/Core/GuidedComponent.cs
@@ -24,11 +24,18 @@ namespace SternGerlach
             //instructionCamera.orthographicSize = sizeModifier + initSize;
             //instructionCamera.rect = new Rect(xModifier + this.initX, yModifier + this.initY, this.width, this.height);
         }
+        void Update()
+        {
+            this.exp = xml.currExp;
+            instSource = exp.source;
+            nbSource.UpdateInstructionColoring(instSource);
+        }
         public void TryEqual()
         {
             this.exp = xml.currExp;
             instSource = exp.source;
             Debug.Log(nbSource.Equals(instSource));
+            nbSource.UpdateInstructionColoring(instSource);
         }
         public void DebugTrees() 
         {

--- a/Assets/Scripts/Core/GuidedComponent.cs
+++ b/Assets/Scripts/Core/GuidedComponent.cs
@@ -16,13 +16,13 @@ namespace SternGerlach
         [SerializeField] Camera instructionCamera;
         private Source instSource;
         // initial camera settings
-        //private float initX = instructionCamera.rect.x, initY = instructionCamera.rect.y, initSize = instructionCamera.orthographicSize;
-        //private float width = instructionCamera.rect.width, height = instructionCamera.rect.height;
+        private float initX = Globals.INST_CAM_INIT_X, initY = Globals.INST_CAM_INIT_Y, initSize = Globals.INST_CAM_INIT_SIZE;
+        private float width = Globals.INST_CAM_INIT_WIDTH, height = Globals.INST_CAM_INIT_HEIGHT;
 
         public void SetCameraSettings(float sizeModifier, float xModifier, float yModifier)
         {
-            //instructionCamera.orthographicSize = sizeModifier + initSize;
-            //instructionCamera.rect = new Rect(xModifier + this.initX, yModifier + this.initY, this.width, this.height);
+            instructionCamera.orthographicSize = sizeModifier + initSize;
+            instructionCamera.rect = new Rect(xModifier + this.initX, yModifier + this.initY, this.width, this.height);
         }
         void Update()
         {
@@ -30,12 +30,12 @@ namespace SternGerlach
             instSource = exp.source;
             nbSource.UpdateInstructionColoring(instSource);
         }
-        public void TryEqual()
+        public bool TryEqual()
         {
             this.exp = xml.currExp;
             instSource = exp.source;
-            Debug.Log(nbSource.Equals(instSource));
             nbSource.UpdateInstructionColoring(instSource);
+            return nbSource.Equals(instSource);
         }
         public void DebugTrees() 
         {
@@ -43,12 +43,8 @@ namespace SternGerlach
             instSource = exp.source;
             Debug.Log("Node builder tree:\n" + nbSource.ToString());
             Debug.Log("Instruction tree:\n" + instSource.ToString());
-            //Debug.Log("gc update");
             exp = xml.currExp;
             instSource = exp.source;
-            //Debug.Log(instSource);
-            //Debug.Log(nbSource);
-            //Debug.Log("complete?: "+ instSource.Equals(nbSource));
         }
     }
 }

--- a/Assets/Scripts/Core/Node.cs
+++ b/Assets/Scripts/Core/Node.cs
@@ -37,9 +37,60 @@ public abstract class Node : MonoBehaviour
     }
     public void UpdateInstructionColoring(Node instructionSource)
     {
-        if (this.Equals(instructionSource)) {
+        if (Equals(instructionSource))
+        {
+            Debug.Log("Trees are equal.");
             ApplyMaterialToTree(instructionSource, GameManager.Instance.correct);
+            return;
         }
+        Debug.Log("Trees are not equal.");
+        ColorMismatchedNodes(instructionSource, this);
+    }
+
+    void ColorMismatchedNodes(Node node1, Node node2)
+    {
+        if (!node1.EqualsNodeOnly(node2))
+        {
+            if (!NodesHaveCorrectRotation(node1, node2))
+            {
+                // Nodes match, but rotation is wrong, so color them yellow.
+                ApplyMaterialToTree(node1, GameManager.Instance.wrongAngle);
+            }
+            else
+            {
+                // Nodes don't match, so color them and their descendants red.
+                ApplyMaterialToTree(node1, GameManager.Instance.wrongNode);
+            }
+        }
+        else
+        {
+            // Nodes match, so color them green.
+            ApplyMaterialToTree(node1, GameManager.Instance.correct);
+        }
+
+        if (node1.children == null || node2.children == null)
+        {
+            return;
+        }
+
+        // Traverse the children and recursively check for mismatches.
+        foreach (var kvp in node1.children)
+        {
+            if (node2.children.TryGetValue(kvp.Key, out Node otherChild))
+            {
+                ColorMismatchedNodes(kvp.Value, otherChild);
+            }
+            else
+            {
+                // Child is missing in the second tree, color it red.
+                ApplyMaterialToTree(kvp.Value, GameManager.Instance.wrongNode);
+            }
+        }
+    }
+
+    bool NodesHaveCorrectRotation(Node node1, Node node2)
+    {
+        return node1.GetRotation() == node2.GetRotation();
     }
     void ApplyMaterialToTree(Node node, Material mat) {
         // apply material to node
@@ -63,6 +114,18 @@ public abstract class Node : MonoBehaviour
             return false;
         }
         if (!ChildrenEqual(otherNode)) {
+            return false;
+        }
+        return true;
+    }
+    private bool EqualsNodeOnly(Node other) {
+        if (other == null || GetType() != other.GetType())
+        {
+            return false;
+        }
+        Node otherNode = (Node)other;
+        if (GetRotation() != otherNode.GetRotation())
+        {
             return false;
         }
         return true;

--- a/Assets/Scripts/Core/PlayerControls.cs
+++ b/Assets/Scripts/Core/PlayerControls.cs
@@ -70,7 +70,9 @@ public class PlayerControls : MonoBehaviour
             builder.DeleteNode();
         }
         if (freeze.WasPressedThisFrame()) {
-            GameManager.Instance.ToggleFreeze();
+            //GameManager.Instance.ToggleFreeze();
+            //guidedComponent.DebugTrees();
+            guidedComponent.TryEqual();
         }
     }
 }

--- a/Assets/Scripts/Globals.cs
+++ b/Assets/Scripts/Globals.cs
@@ -17,5 +17,8 @@ namespace SternGerlach
         internal static float PARTICLE_COOLDOWN = 0.15f;
         internal static string UP_CARET_NAME = "UpCaret";
         internal static string DOWN_CARET_NAME = "DownCaret";
+        // Instruction camera defaults
+        internal static float INST_CAM_INIT_X = 0f, INST_CAM_INIT_Y = 0.5f, INST_CAM_INIT_SIZE = 6.79f;
+        internal static float INST_CAM_INIT_WIDTH = 0.5f, INST_CAM_INIT_HEIGHT = 0.5f;
     }
 }


### PR DESCRIPTION
The colors of the instructions now respond to changes in the scene
Red - wrong node / missing node
Yellow - wrong rotation
Green - Correct node and rotation

Also in this PR
- Camera settings with XML have been fixed
- "Incomplete setup / Complete setup" text has been added